### PR TITLE
Revert "Update peter-evans/create-pull-request action to v7 (#104)"

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -21,7 +21,7 @@ jobs:
           go mod tidy
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@v6
         with:
           token: "${{ secrets.GH_PAT }}"
           add-paths: |


### PR DESCRIPTION
This reverts commit b770748628faf3c0512a1f8f00eb01d176fb3660. Action fails with:

```
  /usr/bin/git symbolic-ref HEAD --short
  main
  Working base is branch 'main'
  /usr/bin/git remote prune origin
  fatal: could not read Username for 'https://github.com/': No such device or address
  Error: The process '/usr/bin/git' failed with exit code 128
```